### PR TITLE
Fixed crash when WaitForSingleObject returns nonsignaled member when Start() and End() were called quickly in succession causing pointers to be deleted while a dependent thread is still running.  Maybe related to http://dotnetinstaller.codeplex.com/discus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bugs
 ----
 * [#10280](http://dotnetinstaller.codeplex.com/workitem/10280): UI displayed briefly if auto_close_if_install set.
 * [#10270](http://dotnetinstaller.codeplex.com/workitem/10270): Run key not deleted on restart.
+* Fixed dotNetInstaller.exe crash when WaitForSingleObject returns nonsignaled member when Start() and End() were called quickly in succession causing pointers to be deleted while a dependent thread is still running
 
 2.0 (9/27/2011)
 ===============

--- a/Documentation/Content/Contributing.aml
+++ b/Documentation/Content/Contributing.aml
@@ -9,10 +9,17 @@
       <para>
         The project is maintained on
         <externalLink>
+          <linkText>GitHub</linkText>
+          <linkUri>https://github.com/dblock/dotnetinstaller</linkUri>
+        </externalLink>, issues on 
+        <externalLink>
           <linkText>CodePlex</linkText>
           <linkUri>http://dotnetinstaller.codeplex.com/</linkUri>
-        </externalLink>. The website has a bug tracking system and a discussions forum. Please don't hesitate to post suggestions
-        or questions.
+        </externalLink>, and discussions on the
+        <externalLink>
+          <linkText>dotNetInstaller Google Group</linkText>
+          <linkUri>http://groups.google.com/group/dotnetinstaller</linkUri>
+        </externalLink>. Please don't hesitate to post suggestions or questions.
       </para>
       <para>
         Keep in mind the following rules of thumb.
@@ -30,7 +37,13 @@
       <steps class="ordered">
         <step>
           <content>
-            <para>Install a command-line Subversion (SVN) client (not TortoiseSVN Shell Extension).</para>
+            <para>
+              Install a Git client.
+              <externalLink>
+                <linkText>github:help</linkText>
+                <linkUri>http://help.github.com/</linkUri>
+              </externalLink>
+            </para>
           </content>
         </step>
         <step>
@@ -68,10 +81,10 @@
         <step>
           <content>
             <para>
-              Check out the source code using SVN from
+              Clone the source code repository from Github at
               <externalLink>
-                <linkText>https://dotnetinstaller.svn.codeplex.com/svn/trunk</linkText>
-                <linkUri>https://dotnetinstaller.svn.codeplex.com/svn/trunk</linkUri>
+                <linkText>https://github.com/dblock/dotnetinstaller.git</linkText>
+                <linkUri>https://github.com/dblock/dotnetinstaller.git</linkUri>
               </externalLink>
             </para>
           </content>
@@ -90,11 +103,8 @@
         <step>
           <content>
             <para>
-              Optionally use Team Foundation Server (TFS) and Team Explorer to establish source control bindings for example, by following the guide here:
-              <externalLink>
-                <linkText>http://codeplex.codeplex.com/wikipage?title=Using TFS and Team Explorer with CodePlex</linkText>
-                <linkUri>http://codeplex.codeplex.com/wikipage?title=Using%20TFS%20and%20Team%20Explorer%20with%20CodePlex</linkUri>
-              </externalLink>
+              If you'd like to update the dotNetInstaller source code (ex. bug fixes and features), fork the project,
+              commit changes to your local repository, push changes to your fork, and then finally make a pull request from your fork.
             </para>
           </content>
         </step>

--- a/dni.sln
+++ b/dni.sln
@@ -19,8 +19,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "doc", "doc", "{2F6E6EC2-78E
 		Release.AspNetCompiler.Debug = "False"
 	EndProjectSection
 	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
 		Documentation\Dni.content = Documentation\Dni.content
 		Documentation\Dni.shfbproj = Documentation\Dni.shfbproj
+		LICENSE = LICENSE
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{C5E3E607-AA22-4796-B113-E9A1BAA374E9}"

--- a/dotNetInstaller/KCBusyProgressCtrl.cpp
+++ b/dotNetInstaller/KCBusyProgressCtrl.cpp
@@ -38,6 +38,12 @@
  *
  *	- Added the outstanding BPM_XXXXX Messages and handlers to the control
  *
+ *	(2012-05-01)
+ *
+ *	- Fixed crash when WaitForSingleObject returns nonsignaled member when Start() and End() were called quickly in succession
+ *	  causing pointers to be deleted while a dependent thread is still running
+ *	  http://www.codeproject.com/Articles/3982/A-new-progress-bar-for-all-occassions#xx1894348xx
+ *
  ****************************************************************************/
 
 #include "stdafx.h"
@@ -417,9 +423,12 @@ void CKCBusyProgressCtrl::End()
 	{
 		if ( m_bBusyThrd )
 			m_bBusyThrd = false;
-		WaitForSingleObject(m_pThrd->m_hThread, m_nSpeed*2);
-		delete m_pThrd;
-		m_pThrd = NULL;
+
+		if ( WaitForSingleObject(m_pThrd->m_hThread, m_nSpeed*2) == WAIT_OBJECT_0 )
+        {
+			delete m_pThrd;
+			m_pThrd = NULL;
+		}
 	}
 	else
 		m_bBusyThrd = false;


### PR DESCRIPTION
Fixed crash when WaitForSingleObject returns nonsignaled member when Start() and End() were called quickly in succession causing pointers to be deleted while a dependent thread is still running.  Maybe related to http://dotnetinstaller.codeplex.com/discussions/343238.

updated contributing documentation to reference GitHub source code repository and dotNetInstaller Google Group.
