### PR TITLE
Added support for new option hide_when_complete_command.

### DIFF
--- a/dotNetInstaller/dotNetInstallerDlg.cpp
+++ b/dotNetInstaller/dotNetInstallerDlg.cpp
@@ -587,6 +587,11 @@ void CdotNetInstallerDlg::Stop()
 	OnOK();
 }
 
+void CdotNetInstallerDlg::Hide()
+{
+	this->ShowWindow(SW_HIDE);
+}
+
 void CdotNetInstallerDlg::StartInstall()
 {
 	if (! InstallUILevelSetting::Instance->IsSilent())

--- a/dotNetInstaller/dotNetInstallerDlg.h
+++ b/dotNetInstaller/dotNetInstallerDlg.h
@@ -68,5 +68,6 @@ private:
 	HINSTANCE GetInstance() const;
 	void StartInstall();
 	void Stop();
+	void Hide();
 	void SetElevationRequired(bool required = true);
 };

--- a/dotNetInstallerLib/InstallConfiguration.cpp
+++ b/dotNetInstallerLib/InstallConfiguration.cpp
@@ -30,6 +30,7 @@ InstallConfiguration::InstallConfiguration()
 	, auto_start(false)
 	, auto_continue_on_reboot(false)
 	, wait_for_complete_command(true)
+	, hide_when_complete_command(false)
 	, show_progress_dialog(true)
 	, show_cab_dialog(true)
 {
@@ -88,6 +89,7 @@ void InstallConfiguration::Load(TiXmlElement * node)
 	complete_command_basic = node->Attribute("complete_command_basic");
 	complete_command_silent = node->Attribute("complete_command_silent");
 	wait_for_complete_command = XmlAttribute(node->Attribute("wait_for_complete_command")).GetBoolValue(true);
+	hide_when_complete_command = XmlAttribute(node->Attribute("hide_when_complete_command")).GetBoolValue(false);
 	auto_close_if_installed = XmlAttribute(node->Attribute("auto_close_if_installed")).GetBoolValue(true);
     auto_close_on_error = XmlAttribute(node->Attribute("auto_close_on_error")).GetBoolValue(false);
 	reload_on_error = XmlAttribute(node->Attribute("reload_on_error")).GetBoolValue(true);

--- a/dotNetInstallerLib/InstallConfiguration.h
+++ b/dotNetInstallerLib/InstallConfiguration.h
@@ -43,6 +43,10 @@ public:
 	bool disable_wow64_fs_redirection; 
 	// wait for the complete command to finish
 	bool wait_for_complete_command;
+
+	// hide the window while waiting for the complete command to finish
+	bool hide_when_complete_command;
+
 	// if true auto close the dialog (display installation_completed or installation_none message 
 	// and execute the complete_command) if all the components are already installed
 	bool auto_close_if_installed;

--- a/dotNetInstallerLib/InstallerUI.cpp
+++ b/dotNetInstallerLib/InstallerUI.cpp
@@ -232,6 +232,12 @@ void InstallerUI::ExecuteCompleteCode(bool components_installed)
 		DWORD dwExitCode = 0;
 		if (p_configuration->wait_for_complete_command)
 		{
+			//hide installer ui when executing complete command
+			if(p_configuration->hide_when_complete_command)
+			{
+				this->Hide();
+			}
+
 			LOG(L"Executing complete command: " << l_complete_command);
 
 			if (p_configuration->disable_wow64_fs_redirection)

--- a/dotNetInstallerLib/InstallerUI.h
+++ b/dotNetInstallerLib/InstallerUI.h
@@ -43,6 +43,7 @@ protected:
 	void AddElevatedControls();
 	virtual void StartInstall() = 0;
 	virtual void Stop() = 0;
+	virtual void Hide() = 0;
 	virtual void ExtractCab(const std::wstring& id, bool display_dialog) = 0;
 	bool ComponentExecError(const ComponentPtr& component, std::exception& ex);
 	bool ComponentExecSuccess(const ComponentPtr& component);

--- a/htmlInstaller/InstallerWindow.cpp
+++ b/htmlInstaller/InstallerWindow.cpp
@@ -586,6 +586,11 @@ void InstallerWindow::Stop()
 	::PostMessage(hwnd, WM_CLOSE, 0,0);
 }
 
+void InstallerWindow::Hide()
+{
+	::ShowWindow(hwnd, SW_HIDE);
+}
+
 std::wstring InstallerWindow::GetPositionStyle(const WidgetPosition& position)
 {
 	std::wstringstream style;

--- a/htmlInstaller/InstallerWindow.h
+++ b/htmlInstaller/InstallerWindow.h
@@ -45,6 +45,7 @@ protected:
 	HWND GetHwnd() const;
 	void StartInstall();
 	void Stop();
+	void Hide();
 	void OnDocumentComplete();
 	// user-defined controls
 	void AddControl(const ControlLabel&);


### PR DESCRIPTION
1. Option Effect:
   If hide_when_complete_command = true Then the installer UI will be hidden when executing the complete command.
2. Option Default Value:
   False
3. Option Prerequisite:
   This option is only valid when wait_for_complete_command = true
