### PR TITLE
Use the NUnit version in the ThirdParty directory.

### DIFF
--- a/UnitTests/InstallerEditorUnitTests/InstallerEditorUnitTests.csproj
+++ b/UnitTests/InstallerEditorUnitTests/InstallerEditorUnitTests.csproj
@@ -44,6 +44,7 @@
     </Reference>
     <Reference Include="nunit.framework, Version=2.4.8.0, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\ThirdParty\NUnit\bin\net-2.0\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/UnitTests/InstallerLibUnitTests/InstallerLibUnitTests.csproj
+++ b/UnitTests/InstallerLibUnitTests/InstallerLibUnitTests.csproj
@@ -46,6 +46,7 @@
     <Reference Include="nunit.framework, Version=2.4.7.0, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
+      <HintPath>..\..\ThirdParty\NUnit\bin\net-2.0\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/UnitTests/dotNetInstallerUnitTests/dotNetInstallerUnitTests.csproj
+++ b/UnitTests/dotNetInstallerUnitTests/dotNetInstallerUnitTests.csproj
@@ -46,6 +46,7 @@
     <Reference Include="nunit.framework, Version=2.4.7.0, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
+      <HintPath>..\..\ThirdParty\NUnit\bin\net-2.0\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/UnitTests/dotNetUnitTestsRunner/dotNetUnitTestsRunner.csproj
+++ b/UnitTests/dotNetUnitTestsRunner/dotNetUnitTestsRunner.csproj
@@ -40,6 +40,7 @@
   <ItemGroup>
     <Reference Include="nunit.framework, Version=2.4.8.0, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\ThirdParty\NUnit\bin\net-2.0\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />


### PR DESCRIPTION
Some of the test projects don't have a HintPath, so they depend on NUnit being installed on the local machine. Since we have a copy of NUnit in the repo, my guess is that we should use it.
