### PR TITLE
Update dotNetInstallerToolsLib/UACElevation.h

### DIFF
--- a/dotNetInstallerToolsLib/UACElevation.h
+++ b/dotNetInstallerToolsLib/UACElevation.h
@@ -55,6 +55,7 @@ typedef struct _TOKEN_ELEVATION {
 namespace DVLib
 {
 	BOOL CreateWellKnownSid(WELL_KNOWN_SID_TYPE WellKnownSidType, PSID DomainSid, PSID pSid, DWORD *cbSid);
+	BOOL CheckTokenMembership(HANDLE TokenHandle, PSID SidToCheck, PBOOL IsMember);
 
 	bool IsUserInAdminGroup();
 	bool IsRunAsAdmin();


### PR DESCRIPTION
Changed to be compatible with Windows 98/Me, since CheckTokenMembership function is not present in advapi32.dll.
