### PR TITLE
Create MSLU.h

### DIFF
--- a/dotNetInstaller/MSLU.h
+++ b/dotNetInstaller/MSLU.h
@@ -1,0 +1,3 @@
+#include "StdAfx.h"
+
+HMODULE __stdcall LoadMSLU(void);


### PR DESCRIPTION
Header file to load unicows.dll on Windows 98/Me
