### PR TITLE
Create MSLULoader.cpp

### DIFF
--- a/htmlInstaller/MSLULoader.cpp
+++ b/htmlInstaller/MSLULoader.cpp
@@ -1,0 +1,5 @@
+#include "StdAfx.h"
+
+// load Microsoft Layer for Unicode (MSLU)
+// http://msdn.microsoft.com/en-us/magazine/cc301794.aspx
+extern "C" HMODULE (__stdcall *_PfnLoadUnicows) (void) = & LoadMSLU;


### PR DESCRIPTION
Is needed to load unicows.dll on Windows 98/Me
