### PR TITLE
Fixed project build settings

### DIFF
--- a/ThirdParty/CabLib/CabLib.vcproj
+++ b/ThirdParty/CabLib/CabLib.vcproj
@@ -20,7 +20,7 @@
 			OutputDirectory="Assembly"
 			IntermediateDirectory="Debug"
 			ConfigurationType="2"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC70.vsprops"
+			InheritedPropertySheets="..\..\dni.vsprops"
 			CharacterSet="2"
 			ManagedExtensions="4"
 			>
@@ -99,7 +99,7 @@
 			OutputDirectory="Assembly"
 			IntermediateDirectory="Release"
 			ConfigurationType="2"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC70.vsprops"
+			InheritedPropertySheets="..\..\dni.vsprops"
 			CharacterSet="2"
 			ManagedExtensions="4"
 			>

--- a/dni.vsprops
+++ b/dni.vsprops
@@ -8,18 +8,18 @@
 	>
 	<Tool
 		Name="VCCLCompilerTool"
-		AdditionalIncludeDirectories="&quot;$(SolutionDir)&quot;"
+		AdditionalIncludeDirectories="&quot;$(SolutionDir)&quot;;$(INCLUDE)"
 		WarningLevel="4"
 		DebugInformationFormat="4"
 	/>
 	<Tool
 		Name="VCLinkerTool"
 		AdditionalOptions="/nod:kernel32.lib /nod:advapi32.lib /nod:user32.lib /nod:gdi32.lib /nod:shell32.lib /nod:comdlg32.lib /nod:version.lib /nod:mpr.lib /nod:rasapi32.lib /nod:winmm.lib /nod:winspool UnicoWS.lib Kernel32.lib Advapi32.lib User32.lib Gdi32.lib Shell32.lib Comdlg32.lib Version.lib Mpr.lib Rasapi32.lib Winmm.lib Winspool.lib Vfw32.lib Secur32.lib Oleacc.lib Oledlg.lib Sensapi.lib Msi.lib"
-		AdditionalLibraryDirectories="&quot;$(SolutionDir)\ThirdParty\Msi\lib&quot;;&quot;$(SolutionDir)\ThirdParty\TinyXml\lib&quot;"
+		AdditionalLibraryDirectories="&quot;$(SolutionDir)\ThirdParty\Msi\lib&quot;;&quot;$(SolutionDir)\ThirdParty\TinyXml\lib&quot;;$(LIB)"
 		GenerateDebugInformation="true"
 	/>
 	<Tool
 		Name="VCResourceCompilerTool"
-		AdditionalIncludeDirectories="&quot;$(IntDir)&quot;;&quot;$(SolutionDir)&quot;"
+		AdditionalIncludeDirectories="&quot;$(IntDir)&quot;;&quot;$(SolutionDir)&quot;;$(INCLUDE)"
 	/>
 </VisualStudioPropertySheet>


### PR DESCRIPTION
I tried building on a machine that didn't have Visual Studio 2005 (I have 2010 and 2012) and ran into some compile errors that turned out to be related to include and library paths:
1. The environment variables defined in `build.cmd` were not automatically used and needed to be added to `dni.vsprops`.
2. The `CabLib` project had not been updated to use `dni.vsprops`, so it now does.
